### PR TITLE
Remove unnecessary code from the admin cog

### DIFF
--- a/Functions/Admin/admin.py
+++ b/Functions/Admin/admin.py
@@ -1,24 +1,23 @@
-import  discord
 import random
+
 from discord.ext import commands
-from discord.ext.commands import has_permissions, CheckFailure
 
 
 class admin(commands.Cog):
+
     def __init__(self, bot):
         self.bot = bot
-        self._last_member = None
 
-
-    give_list =[]
     @commands.command()
-    @has_permissions(administrator=True)
-    async def giveaway(self,ctx):
-        members = ctx.guild.members
-        for i in members:
-            self.give_list.append(i)
-        winner = random.choice(self.give_list)
-        await ctx.send(f"Winner: {winner}")
+    @commands.has_permissions(administrator=True)
+    @commands.guild_only()
+    async def giveaway(self, ctx):
+        """
+        Picks a random user from the server to win your giveaway.
+        """
+
+        winner = random.choice(ctx.guild.members)
+        await ctx.send(f"Winner: {winner.mention}")
 
 def setup(bot):
     bot.add_cog(admin(bot))


### PR DESCRIPTION
* The use of `give_list` entirely falls apart should the bot be on multiple servers, since it isn't cleared afterwards
* The use of `give_list` is redundant because `Guild.members` is _already_ a list
* Fixed command failing in DMs
* Fixed multiple imports from the same module
* Ping the user who won the giveaway